### PR TITLE
OCPBUGS-86846: [release-4.20] filter out "remove" patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Azure/azure-workload-identity
 
-go 1.22
-
-toolchain go1.22.1
+go 1.22.1
 
 require (
 	github.com/Azure/aad-pod-identity v1.8.13
@@ -105,7 +103,7 @@ require (
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -161,7 +162,21 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 		logger.Error("failed to marshal pod object", err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+	resp := admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+	// Filter out "remove" patches that result from the JSON roundtrip through
+	// Go structs dropping fields unknown to the vendored k8s.io/api version
+	// (e.g. Container.RestartPolicy added in k8s 1.28).
+	filtered := make([]jsonpatch.JsonPatchOperation, 0, len(resp.Patches))
+	for _, p := range resp.Patches {
+		if p.Operation != "remove" {
+			filtered = append(filtered, p)
+		}
+	}
+	resp.Patches = filtered
+	if len(filtered) == 0 {
+		resp.PatchType = nil
+	}
+	return resp
 }
 
 // PodMutator implements admission.DecoderInjector

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -730,6 +730,7 @@ func TestHandle(t *testing.T) {
 		name               string
 		serviceAccountName string
 		podLabels          map[string]string
+		rawPod             []byte
 		clientObjects      []client.Object
 		readerObjects      []client.Object
 	}{
@@ -763,6 +764,12 @@ func TestHandle(t *testing.T) {
 			clientObjects: serviceAccounts,
 			readerObjects: nil,
 		},
+		{
+			name:          "pod has the required label, restart policy in init container",
+			rawPod:        []byte(`{"metadata":{"name":"pod","namespace":"ns1","creationTimestamp":null,"labels":{"azure.workload.identity/use":"true"}},"spec":{"initContainers":[{"name":"init-container","image":"init-container-image","restartPolicy":"Always"}],"containers":[{"name":"container","image":"image","resources":{}}]}}`),
+			clientObjects: serviceAccounts,
+			readerObjects: nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -778,6 +785,11 @@ func TestHandle(t *testing.T) {
 				decoder: decoder,
 			}
 
+			rawPod := test.rawPod
+			if rawPod == nil {
+				rawPod = newPodRaw("pod", "ns1", test.serviceAccountName, test.podLabels)
+			}
+
 			req := atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
@@ -785,7 +797,7 @@ func TestHandle(t *testing.T) {
 						Version: "v1",
 						Kind:    "Pod",
 					},
-					Object:    runtime.RawExtension{Raw: newPodRaw("pod", "ns1", test.serviceAccountName, test.podLabels)},
+					Object:    runtime.RawExtension{Raw: rawPod},
 					Namespace: "ns1",
 					Operation: admissionv1.Create,
 				},
@@ -794,6 +806,11 @@ func TestHandle(t *testing.T) {
 			resp := m.Handle(context.Background(), req)
 			if !resp.Allowed {
 				t.Fatalf("expected to be allowed")
+			}
+			for _, patch := range resp.Patches {
+				if patch.Operation == "remove" {
+					t.Errorf("expected no remove patches, got: %v", patch)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
so that the webhook does not remove bits from k8s API newer than 1.26

Surgical fix for https://github.com/Azure/azure-workload-identity/issues/1312  , backported to 4.20 (without having to update k8s api dependency, which we probably don't want to do for `release-20` branch.

Assisted-by: Claude Code