### PR TITLE
NO-ISSUE: Update OWNERS: remove 2uasimojo, suhanime, lleshchi

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,5 @@
 approvers:
-- 2uasimojo
-- suhanime
 - dlom
 - jstuever
-- lleshchi
 
 component: "Cloud Credential Operator"


### PR DESCRIPTION
Suhani and I were never truly owners of this repo, just backups due to arbitrary org chart lines. In the advent of PIXAA, we're really not owners anymore.

...and Leah left RH some time ago.